### PR TITLE
write_stylus: removed desktop icons

### DIFF
--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -7,7 +7,6 @@ stdenv.mkDerivation rec {
     name = "Write";
     exec = "Write";
     comment = "A word processor for handwriting";
-    icon = "write_stylus";
     desktopName = "Write";
     genericName = "Write";
     categories = "Office;Graphics";
@@ -16,13 +15,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "http://www.styluslabs.com/write/write${version}.tar.gz";
     sha256 = "1p6glp4vdpwl8hmhypayc4cvs3j9jfmjfhhrgqm2xkgl5bfbv2qd";
-  };
-
-  # taken from: https://www.iconfinder.com/icons/50835/edit_pencil_write_icon
-  # license: Free for commercial use
-  icon = fetchurl {
-    url = "https://oyra.eu/write/icon.tar.gz";
-    sha256 = "1zd98g63apwi17qc1hm1g14maain5d18g4afadxm30qjz2s0mvs8";
   };
 
   sourceRoot = ".";
@@ -34,9 +26,6 @@ stdenv.mkDerivation rec {
     cp -R Write $out/
     # symlink the binary to bin/
     ln -s $out/Write/Write $out/bin/Write
-
-    # untar icons
-    tar -xzf ${icon} *.tar.gz -C $out/
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/


### PR DESCRIPTION
###### Motivation for this change
Icons are no longer available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
